### PR TITLE
Implementation of RegisterParser

### DIFF
--- a/Jacdac.Tests/Jacdac.Tests.csproj
+++ b/Jacdac.Tests/Jacdac.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Jacdac\Jacdac.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Jacdac.Tests/RegisterParserTests.cs
+++ b/Jacdac.Tests/RegisterParserTests.cs
@@ -86,8 +86,6 @@ namespace Jacdac.Tests
             var format = "u8 u16[]";
             var parsed = RegisterParser.ParseBuffer(format, buffer);
 
-            // 43981 4660 22136
-
             Assert.False(parsed.IsSingleValue);
             Assert.IsType<byte>(parsed.Values[0]);
             Assert.Equal<byte>(127, parsed.GetValue<byte>(0));
@@ -104,8 +102,6 @@ namespace Jacdac.Tests
             var buffer = new byte[] { 0x7F, 0xCD, 0xAB, 0x34, 0x12, 0xFF };
             var format = "u8 u16[2] u8";
             var parsed = RegisterParser.ParseBuffer(format, buffer);
-
-            // 43981 4660 22136
 
             Assert.False(parsed.IsSingleValue);
             Assert.IsType<byte>(parsed.Values[0]);

--- a/Jacdac.Tests/RegisterParserTests.cs
+++ b/Jacdac.Tests/RegisterParserTests.cs
@@ -62,7 +62,48 @@ namespace Jacdac.Tests
 
             Assert.True(parsed.IsSingleValue);
             Assert.IsType<string>(parsed.Value);
-            Assert.Equal<string>("Hello World", parsed.Value);
+            Assert.Equal("Hello World", parsed.Value);
+        }
+
+        [Fact]
+        public void ParseExhaustingArray()
+        {
+            var buffer = new byte[] { 0x7F, 0xCD, 0xAB, 0x34, 0x12, 0x78, 0x56 };
+            var format = "u8 u16[]";
+            var parsed = RegisterParser.ParseBuffer(format, buffer);
+
+            // 43981 4660 22136
+
+            Assert.False(parsed.IsSingleValue);
+            Assert.IsType<byte>(parsed.Values[0]);
+            Assert.Equal<byte>(127, parsed.GetValue<byte>(0));
+
+            Assert.IsType<ushort>(parsed.Values[1]);
+            Assert.Equal<ushort>(43981, parsed.GetValue<ushort>(1));
+            Assert.Equal<ushort>(4660, parsed.GetValue<ushort>(2));
+            Assert.Equal<ushort>(22136, parsed.GetValue<ushort>(3));
+        }
+
+        [Fact]
+        public void ParseSizeArray()
+        {
+            var buffer = new byte[] { 0x7F, 0xCD, 0xAB, 0x34, 0x12, 0xFF };
+            var format = "u8 u16[2] u8";
+            var parsed = RegisterParser.ParseBuffer(format, buffer);
+
+            // 43981 4660 22136
+
+            Assert.False(parsed.IsSingleValue);
+            Assert.IsType<byte>(parsed.Values[0]);
+            Assert.Equal<byte>(127, parsed.GetValue<byte>(0));
+
+            Assert.IsType<object[]>(parsed.Values[1]);
+            Assert.IsType<ushort>(parsed.Values[1][0]);
+            Assert.Equal<ushort>(43981, (ushort) parsed.GetValue<object[]>(1)[0]);
+            Assert.Equal<ushort>(4660, (ushort) parsed.GetValue<object[]>(1)[1]);
+
+            Assert.IsType<byte>(parsed.Values[2]);
+            Assert.Equal<byte>(255, parsed.GetValue<byte>(2));
         }
 
         [Theory]

--- a/Jacdac.Tests/RegisterParserTests.cs
+++ b/Jacdac.Tests/RegisterParserTests.cs
@@ -66,6 +66,20 @@ namespace Jacdac.Tests
         }
 
         [Fact]
+        public void ParseTerminatedString()
+        {
+            var buffer = new byte[] { 72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 0, 0xFF };
+            var format = "z u8";
+            var parsed = RegisterParser.ParseBuffer(format, buffer);
+
+            Assert.False(parsed.IsSingleValue);
+            Assert.IsType<string>(parsed.Values[0]);
+            Assert.IsType<byte>(parsed.Values[1]);
+            Assert.Equal("Hello World", parsed.GetValue<string>(0));
+            Assert.Equal<byte>(255, parsed.GetValue<byte>(1));
+        }
+
+        [Fact]
         public void ParseExhaustingArray()
         {
             var buffer = new byte[] { 0x7F, 0xCD, 0xAB, 0x34, 0x12, 0x78, 0x56 };
@@ -116,6 +130,10 @@ namespace Jacdac.Tests
             new byte[] { 0x7F, 0xFF, 0x15, 0x1, 0x3B, 0x1, 0xEF, 0xEF },
             "u8 u8 r: u16",
             new object[] { 127, 255, 277, 315, 61423 })]
+        [InlineData(
+            new byte[] { 0x7F, 0xFF, 72, 101, 108, 108, 111, 0, 1, 87, 111, 114, 108, 100, 0 },
+            "u8 r: u8 z",
+            new object[] { 127, 255, "Hello", 1, "World"})]
         public void ParseArbitrary(byte[] buffer, string format, dynamic[] expectedValues)
         {
             var parsed = RegisterParser.ParseBuffer(format, buffer);

--- a/Jacdac.Tests/RegisterParserTests.cs
+++ b/Jacdac.Tests/RegisterParserTests.cs
@@ -1,0 +1,87 @@
+using System;
+using Xunit;
+
+namespace Jacdac.Tests
+{
+    public class RegisterParserTests
+    {
+        [Fact]
+        public void ParseSimpleBuffer()
+        {
+            var buffer = new byte[] { 0x1, 0x2, 0x3, 0x4 };
+            var format = "b";
+            var parsed = RegisterParser.ParseBuffer(format, buffer);
+
+            Assert.True(parsed.IsSingleValue);
+            Assert.IsType<byte[]>(parsed.Value);
+            Assert.Equal<byte[]>(parsed.Value, buffer);
+        }
+
+        [Fact]
+        public void ParseSimpleNumber()
+        {
+            var buffer = new byte[] { 0x92, 0x10, 0x0, 0x0 };
+            var format = "u32";
+            var parsed = RegisterParser.ParseBuffer(format, buffer);
+
+            Assert.True(parsed.IsSingleValue);
+            Assert.IsType<UInt32>(parsed.Value);
+            Assert.Equal<UInt32>(4242, parsed.GetValue<UInt32>());
+        }
+
+        [Fact]
+        public void ParseTwoSimpleNumbers()
+        {
+            var buffer = new byte[] { 0x92, 0x10, 0x0, 0x0, 0xCF, 0x7, 0x0, 0x0 };
+            var format = "u32 u32";
+            var parsed = RegisterParser.ParseBuffer(format, buffer);
+
+            Assert.True(2 == parsed.Values.Length);
+            Assert.True(4242 == parsed.GetValue<uint>(0));
+            Assert.True(1999 == parsed.GetValue<uint>(1));
+        }
+
+        [Fact]
+        public void ParseFloat()
+        {
+            var buffer = new byte[] { 0x7F, 0xFF };
+            var format = "u8.8";
+            var parsed = RegisterParser.ParseBuffer(format, buffer);
+
+            Assert.True(parsed.IsSingleValue);
+            Assert.IsType<float>(parsed.Value);
+            Assert.Equal<float>(255.4961f, parsed.Value);
+        }
+
+        [Fact]
+        public void ParseString()
+        {
+            var buffer = new byte[] { 72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100 };
+            var format = "s";
+            var parsed = RegisterParser.ParseBuffer(format, buffer);
+
+            Assert.True(parsed.IsSingleValue);
+            Assert.IsType<string>(parsed.Value);
+            Assert.Equal<string>("Hello World", parsed.Value);
+        }
+
+        [Theory]
+        [InlineData(new byte[] {0xFF, 0xFF}, "u8 u8", new object[] { 255, 255 })]
+        [InlineData(
+            new byte[] { 0x7F, 72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100 }, 
+            "u8 s", 
+            new object[] { 127, "Hello World" })]
+        [InlineData(
+            new byte[] { 0x7F, 0xFF, 0x15, 0x1, 0x3B, 0x1, 0xEF, 0xEF },
+            "u8 u8 r: u16",
+            new object[] { 127, 255, 277, 315, 61423 })]
+        public void ParseArbitrary(byte[] buffer, string format, dynamic[] expectedValues)
+        {
+            var parsed = RegisterParser.ParseBuffer(format, buffer);
+            for(int i = 0; i < expectedValues.Length; i++)
+            {
+                Assert.True(parsed.Values[i] == expectedValues[i]);
+            }
+        }
+    }
+}

--- a/Jacdac.sln
+++ b/Jacdac.sln
@@ -12,6 +12,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jacdac.Tests", "Jacdac.Tests\Jacdac.Tests.csproj", "{5540EEE8-5DA1-4FCF-9721-81E65E6244C3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,6 +28,10 @@ Global
 		{D736AFDA-90FA-472E-AD8E-40E81EBD06B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D736AFDA-90FA-472E-AD8E-40E81EBD06B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D736AFDA-90FA-472E-AD8E-40E81EBD06B1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5540EEE8-5DA1-4FCF-9721-81E65E6244C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5540EEE8-5DA1-4FCF-9721-81E65E6244C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5540EEE8-5DA1-4FCF-9721-81E65E6244C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5540EEE8-5DA1-4FCF-9721-81E65E6244C3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Jacdac/JDRegister.cs
+++ b/Jacdac/JDRegister.cs
@@ -9,6 +9,8 @@ namespace Jacdac
 {
     public class JDRegister<T> : JDRegister
     {
+        private const int REFRESH_TIMEOUT_MS = 500;
+
         private T cachedValue;
 
         public T Value => GetValue().GetAwaiter().GetResult();
@@ -23,7 +25,7 @@ namespace Jacdac
         {
             var requiresRefresh = forceRefresh;
 
-            if ((DateTime.Now - LastFetched).TotalMilliseconds > 500)
+            if ((DateTime.Now - LastFetched).TotalMilliseconds > REFRESH_TIMEOUT_MS)
                 requiresRefresh = true;
 
             if (requiresRefresh)

--- a/Jacdac/JDRegister.cs
+++ b/Jacdac/JDRegister.cs
@@ -1,0 +1,66 @@
+﻿using Jacdac.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Jacdac
+{
+    public class JDRegister<T> : JDRegister
+    {
+        private T cachedValue;
+
+        public T Value => GetValue().GetAwaiter().GetResult();
+
+        public DateTime LastFetched { get; private set; }
+
+        public JDRegister(ushort address, RegisterFlags flags, JDService service) : base(address, flags, service)
+        {
+        }
+
+        public async Task<T> GetValue(bool forceRefresh = false)
+        {
+            var requiresRefresh = forceRefresh;
+
+            if ((DateTime.Now - LastFetched).TotalMilliseconds > 500)
+                requiresRefresh = true;
+
+            if (requiresRefresh)
+                cachedValue = await FetchValue();
+
+            return cachedValue;
+        } 
+
+        private async Task<T> FetchValue()
+        {
+            var resultBuffer = await Service.ReadRegister(Address);
+            // Parse the result buffer here
+            return default(T);
+        }
+    }
+
+    public class JDRegister
+    {
+        public JDRegister(ushort address, RegisterFlags flags, JDService service)
+        {
+            Address = address;
+            Service = service;
+            Flags = flags;
+        }
+
+        public ushort Address { get; }
+        public JDService Service { get; }
+
+        public RegisterFlags Flags { get; }
+    }
+
+    [Flags]
+    public enum RegisterFlags
+    {
+        Read,
+        Write,
+        Const,
+        Client
+    }
+}

--- a/Jacdac/Jacdac.csproj
+++ b/Jacdac/Jacdac.csproj
@@ -1,16 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
-    <ApplicationIcon />
-    <StartupObject />
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<TargetFramework>net5.0</TargetFramework>
+		<ApplicationIcon />
+		<StartupObject />
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="LibUsbDotNet" Version="2.2.29" />
-    <PackageReference Include="NullFX.CRC" Version="1.1.2" />
-    <PackageReference Include="System.Collections" Version="4.3.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="LibUsbDotNet" Version="2.2.29" />
+		<PackageReference Include="NullFX.CRC" Version="1.1.2" />
+		<PackageReference Include="System.Collections" Version="4.3.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>Jacdac.Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
 
 </Project>

--- a/Jacdac/RegisterParser.cs
+++ b/Jacdac/RegisterParser.cs
@@ -1,0 +1,350 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Jacdac
+{
+    enum NumberFormat
+    {
+        Int8LE = 1,
+        UInt8LE = 2,
+        Int16LE = 3,
+        UInt16LE = 4,
+        Int32LE = 5,
+        Int8BE = 6,
+        UInt8BE = 7,
+        Int16BE = 8,
+        UInt16BE = 9,
+        Int32BE = 10,
+        UInt32LE = 11,
+        UInt32BE = 12,
+        Float32LE = 13,
+        Float64LE = 14,
+        Float32BE = 15,
+        Float64BE = 16,
+        UInt64LE = 17,
+        UInt64BE = 18,
+        Int64LE = 19,
+        Int64BE = 20,
+        None
+    }
+
+    internal static class RegisterParser
+    {
+        private static byte GetNumberSize(NumberFormat format)
+        {
+            switch (format)
+            {
+                case NumberFormat.Int8LE:
+                case NumberFormat.UInt8LE:
+                case NumberFormat.Int8BE:
+                case NumberFormat.UInt8BE:
+                    return 1;
+                case NumberFormat.Int16LE:
+                case NumberFormat.UInt16LE:
+                case NumberFormat.Int16BE:
+                case NumberFormat.UInt16BE:
+                    return 2;
+                case NumberFormat.Int32LE:
+                case NumberFormat.Int32BE:
+                case NumberFormat.UInt32BE:
+                case NumberFormat.UInt32LE:
+                case NumberFormat.Float32BE:
+                case NumberFormat.Float32LE:
+                    return 4;
+                case NumberFormat.UInt64BE:
+                case NumberFormat.Int64BE:
+                case NumberFormat.UInt64LE:
+                case NumberFormat.Int64LE:
+                case NumberFormat.Float64BE:
+                case NumberFormat.Float64LE:
+                    return 8;
+                default:
+                    return 0;
+            }
+        }
+
+        private static NumberFormat GetNumberFormatOfType(string tp)
+        {
+            switch (tp)
+            {
+                case "u8":
+                    return NumberFormat.UInt8LE;
+                case "u16":
+                    return NumberFormat.UInt16LE;
+                case "u32":
+                    return NumberFormat.UInt32LE;
+                case "i8":
+                    return NumberFormat.Int8LE;
+                case "i16":
+                    return NumberFormat.Int16LE;
+                case "i32":
+                    return NumberFormat.Int32LE;
+                case "f32":
+                    return NumberFormat.Float32LE;
+                case "f64":
+                    return NumberFormat.Float64LE;
+                case "i64":
+                    return NumberFormat.Int64LE;
+                case "u64":
+                    return NumberFormat.UInt64LE;
+                default:
+                    return NumberFormat.None;
+            }
+        }
+
+        public static dynamic ParseNumber(NumberFormat format, ReadOnlySpan<byte> buffer) => format switch
+        {
+            NumberFormat.UInt8LE => buffer[0],
+            NumberFormat.Int8LE => buffer[0],
+            NumberFormat.UInt16LE => BitConverter.ToUInt16(buffer),
+            NumberFormat.Int16LE => BitConverter.ToInt16(buffer),
+            NumberFormat.UInt32LE => BitConverter.ToUInt32(buffer),
+            NumberFormat.Int32LE => BitConverter.ToInt32(buffer),
+            NumberFormat.UInt64LE => BitConverter.ToUInt64(buffer),
+            NumberFormat.Int64LE => BitConverter.ToInt64(buffer),
+            _ => 0
+        };
+
+        public static dynamic CastNumber(NumberFormat format, dynamic number) => format switch
+        {
+            NumberFormat.UInt8LE => (byte)number,
+            NumberFormat.Int8LE => (byte)number,
+            NumberFormat.UInt16LE => (ushort)number,
+            NumberFormat.Int16LE => (short)number,
+            NumberFormat.UInt32LE => (UInt32) number,
+            NumberFormat.Int32LE => (Int32)number,
+            NumberFormat.UInt64LE => (UInt64)number,
+            NumberFormat.Int64LE => (Int64)number,
+            _ => 0
+        };
+
+        private enum TokenType
+        {
+            None,
+            Number,
+            Buffer,
+            String,
+            TerminatedString,
+            Repeat,
+            Padding
+        }
+
+        private static TokenType GetTokenType(char chr) => chr switch
+        {
+            'u' => TokenType.Number,
+            'i' => TokenType.Number,
+            'b' => TokenType.Buffer,
+            's' => TokenType.String,
+            'z' => TokenType.TerminatedString,
+            'x' => TokenType.Padding,
+            'r' => TokenType.Repeat,
+            _ => TokenType.None
+        };
+
+        private struct TokenResult
+        {
+            public TokenType Type { get; set; }
+
+            public NumberFormat NumberFormat { get; set; }
+
+            public byte Count { get; set; }
+
+            public bool IsSigned { get; set; }
+
+            public int Divisor { get; set; }
+
+            public bool ExhaustBuffer { get; set; }
+        }
+
+        private static TokenResult[] ParseFormat(string fmt)
+        {
+            var tokenStrs = fmt.Split(' ');
+            var tokens = new TokenResult[tokenStrs.Length];
+
+            for (int i = 0; i < tokenStrs.Length; i++)
+            {
+                var fpr = 0;
+
+                var tokenRes = new TokenResult();
+
+                var str = tokenStrs[i];
+                tokenRes.Type = GetTokenType(str[fpr]);
+                tokenRes.IsSigned = str[fpr] == 'i';
+                tokenRes.Count = 1;
+
+                fpr++;
+
+                if (tokenRes.Type == TokenType.Number && fpr < str.Length)
+                {
+                    var endIdx = str.Length - 1;
+                    var brIdx = str.IndexOf('[');
+                    var readUntil = brIdx > 0 ? brIdx : endIdx;
+
+                    var ptIdx = str.IndexOf('.');
+                    if (ptIdx > 0)
+                    {
+                        var sz1 = byte.Parse(str.Substring(fpr, ptIdx - fpr));
+                        var sz2 = byte.Parse(str.Substring(ptIdx + 1, readUntil - ptIdx));
+                        tokenRes.Divisor = 1 << sz2;
+                        tokenRes.NumberFormat = GetNumberFormatOfType(str[0] + (sz1 + sz2).ToString());
+                    }
+                    else
+                    {
+                        tokenRes.NumberFormat = GetNumberFormatOfType(str.Substring(0, readUntil + 1));
+                    }
+                    fpr = readUntil;
+                }
+
+                if (fpr < str.Length && str[fpr] == '[')
+                {
+                    tokenRes.Count = byte.Parse(str.Substring(fpr + 1, str.Length - 2));
+
+                }
+                else if (tokenRes.Type == TokenType.Buffer || tokenRes.Type == TokenType.String)
+                    tokenRes.ExhaustBuffer = true;
+
+                tokens[i] = tokenRes;
+            }
+
+            return tokens;
+        }
+
+        public struct ParseResult
+        {
+            public bool IsSingleValue => Values.Length == 1;
+
+            public dynamic[] Values { get; private set; }
+
+            public dynamic Value => Values[0];
+
+            public T GetValue<T>(int idx = 0)
+            {
+                if (idx > Values.Length)
+                    throw new ArgumentOutOfRangeException();
+
+                return (T)Values[idx];
+            }
+
+            public ParseResult(dynamic[] values)
+            {
+                Values = values;
+            }
+        }
+
+        public static ParseResult ParseBuffer(string fmt, byte[] buffer)
+        {
+            var trm = fmt.Trim();
+
+            if (trm == "b")
+                return new ParseResult(new dynamic[] { buffer });
+
+            var numberFormat = GetNumberFormatOfType(fmt);
+            ReadOnlySpan<byte> spn = buffer;
+            if (numberFormat != NumberFormat.None)
+            {
+                var size = GetNumberSize(numberFormat);
+                if (buffer.Length < size)
+                    throw new ArgumentOutOfRangeException($"Buffer too small. Expected size {size}, got {buffer.Length}");
+
+                return new ParseResult(new dynamic[] { ParseNumber(numberFormat, spn) });
+            }
+
+            var results = new List<dynamic>();
+            var tokens = ParseFormat(fmt);
+
+            var repeatIndex = -1;
+            var bufSlice = spn;
+            for (int i = 0; i < tokens.Length; i++)
+            {
+                var token = tokens[i];
+
+                if (token.Type == TokenType.Repeat)
+                {
+                    repeatIndex = i;
+                    continue;
+                }
+
+                var element = ParseElement(token, bufSlice, out var consumed);
+                results.Add(element);
+                bufSlice = bufSlice.Slice(consumed);
+
+                if (bufSlice.Length == 0)
+                    break;
+
+                if (repeatIndex > 0 && i == tokens.Length - 1)
+                    i = repeatIndex;
+            }
+
+            return new ParseResult(results.ToArray());
+        }
+
+        private static dynamic ParseElement(TokenResult token, ReadOnlySpan<byte> buffer, out int consumed)
+        {
+            var length = token.ExhaustBuffer ? buffer.Length : token.Count;
+            consumed = length;
+
+            if (token.Type == TokenType.Number)
+            {
+                dynamic[] entries = new dynamic[token.Count];
+                int bfStart = 0;
+                var numberSize = GetNumberSize(token.NumberFormat);
+                for (int i = 0; i < entries.Length; i++)
+                {
+
+                    dynamic number = ParseNumber(token.NumberFormat, buffer.Slice(bfStart, numberSize));
+                    bfStart += numberSize;
+
+                    if (token.IsSigned)
+                    {
+                        if (token.Divisor > 0)
+                            entries[i] = (long)number / (float)token.Divisor;
+                       else 
+                            entries[i] = CastNumber(token.NumberFormat, number);
+                    }
+                    else
+                    {
+                        if (token.Divisor > 0)
+                            entries[i] = (ulong)number / (float)token.Divisor;
+                        else
+                            entries[i] = CastNumber(token.NumberFormat, number);
+                    }
+                }
+
+                consumed = numberSize * token.Count;
+
+                if (entries.Length == 1)
+                    return entries[0];
+
+                return entries;
+            }
+            else if(token.Type == TokenType.TerminatedString)
+            {
+                length = buffer.IndexOf((byte)0);
+                if (length < 0)
+                    length = buffer.Length;
+
+                consumed = length;
+
+                return Encoding.UTF8.GetString(buffer.Slice(0, length));
+            }
+            else if(token.Type == TokenType.String)
+            {
+                return Encoding.UTF8.GetString(buffer.Slice(0, length));
+            }
+            else if(token.Type == TokenType.Buffer)
+            {
+                return buffer.Slice(0, length).ToArray();
+            } else if(token.Type == TokenType.Padding)
+            {
+                return null;
+            }
+
+            consumed = 0;
+            return null;
+        }
+    }
+
+}

--- a/Jacdac/RegisterParser.cs
+++ b/Jacdac/RegisterParser.cs
@@ -31,6 +31,28 @@ namespace Jacdac
         None
     }
 
+    public struct ParseResult
+    {
+        public bool IsSingleValue => Values.Length == 1;
+
+        public dynamic[] Values { get; private set; }
+
+        public dynamic Value => Values[0];
+
+        public T GetValue<T>(int idx = 0)
+        {
+            if (idx > Values.Length)
+                throw new ArgumentOutOfRangeException();
+
+            return (T)Values[idx];
+        }
+
+        public ParseResult(dynamic[] values)
+        {
+            Values = values;
+        }
+    }
+
     internal static class RegisterParser
     {
         private static byte GetNumberSize(NumberFormat format)
@@ -217,28 +239,6 @@ namespace Jacdac
             }
 
             return tokens;
-        }
-
-        public struct ParseResult
-        {
-            public bool IsSingleValue => Values.Length == 1;
-
-            public dynamic[] Values { get; private set; }
-
-            public dynamic Value => Values[0];
-
-            public T GetValue<T>(int idx = 0)
-            {
-                if (idx > Values.Length)
-                    throw new ArgumentOutOfRangeException();
-
-                return (T)Values[idx];
-            }
-
-            public ParseResult(dynamic[] values)
-            {
-                Values = values;
-            }
         }
 
         public static ParseResult ParseBuffer(string fmt, byte[] buffer)

--- a/Jacdac/RegisterParser.cs
+++ b/Jacdac/RegisterParser.cs
@@ -201,6 +201,7 @@ namespace Jacdac
 
                 fpr++;
 
+                // If we have a number token, figure out whether it is a float
                 if (tokenRes.Type == TokenType.Number && fpr < str.Length)
                 {
                     var endIdx = str.Length;
@@ -222,6 +223,7 @@ namespace Jacdac
                     fpr = readUntil;
                 }
 
+                // Figure out whether we have an (unbounded) array
                 if (fpr < str.Length && str[fpr] == '[')
                 {
                     tokenRes.IsArray = true;

--- a/Jacdac/RegisterParser.cs
+++ b/Jacdac/RegisterParser.cs
@@ -335,7 +335,7 @@ namespace Jacdac
                 if (length < 0)
                     length = buffer.Length;
 
-                consumed = length;
+                consumed = length + 1;
 
                 return Encoding.UTF8.GetString(buffer.Slice(0, length));
             }


### PR DESCRIPTION
This PR contains the implementation of the RegisterParser, similar to the approach in _jacdac-ts_.

The actual register implementation is not part of this PR as it might require some architecture changes. 
`JDRegister` and `JDRegister<T>` here are merely meant as a baseline/idea.